### PR TITLE
Fix for use of flatMap in Swift 4.1+

### DIFF
--- a/SwiftNotificationCenter/WeakObjectSet.swift
+++ b/SwiftNotificationCenter/WeakObjectSet.swift
@@ -41,7 +41,11 @@ struct WeakObjectSet<T: AnyObject>: Sequence {
     }
     
     var allObjects: [T] {
-        return objects.flatMap { $0.object }
+        #if swift(>=4.1)
+            return objects.compactMap { $0.object }
+        #else
+            return objects.flatMap { $0.object }
+        #endif
     }
     
     func contains(_ object: T) -> Bool {


### PR DESCRIPTION
Hi,

Thanks for creating SwiftNotificationCenter!

In Swift 4.1 and beyond, using `flatMap` on optional values is deprecated and one should use `compactMap`. Since this is only used in once place, I simply added a compiler directive to use the correct method based on the Swift version.