### PR TITLE
fix for xcode10 debug crashes

### DIFF
--- a/SwiftNotificationCenter/WeakObjectSet.swift
+++ b/SwiftNotificationCenter/WeakObjectSet.swift
@@ -53,11 +53,15 @@ struct WeakObjectSet<T: AnyObject>: Sequence {
     }
     
     mutating func add(_ object: T) {
-        self.objects.formUnion([WeakObject(object)])
+        var obs = self.objects.compactMap{ $0 }
+        obs.append(WeakObject(object))
+        self.objects = Set<WeakObject<T>>(obs)
     }
     
     mutating func add(_ objects: [T]) {
-        self.objects.formUnion(objects.map{WeakObject($0)})
+        var obs = self.objects.compactMap{ $0 }
+        obs.append(contentsOf: objects.compactMap{ WeakObject($0) })
+        self.objects = Set<WeakObject<T>>(obs)
     }
     
     mutating func remove(_ object: T) {


### PR DESCRIPTION
Crash was happening due having some nil objects inside `self.objects` variable.

What I did was a quick fix for having the build working with swift 4.2 and being able to ship my app back to production.

PR's code is about removing all `nil` objects inside `self.objects` before adding new ones.